### PR TITLE
RelWithDebugInfo causes the image to inflate

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -43,7 +43,6 @@ cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
          -DWITH_EMBEDDED_SERVER=ON \
          -DWITH_UNIT_TESTS=OFF \
          -DINSTALL_MYSQLTESTDIR= \
-         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
          -DWITH_WSREP=OFF \
          ..
 make -j ${CPU_COUNT}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   missing_dso_whitelist:
     - /usr/lib/libncurses.5.4.dylib  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,7 +67,7 @@ test:
 
 about:
   home: https://tiledb.com
-  license: GPLv2
+  license: GPL-2.0-only
   license_family: GPL
   license_file: COPYING
   summary: libtiledb-sql is a SQL interface for TileDB arrays using the MyTile storage engine


### PR DESCRIPTION
On linux the conda package gains 400MB with the extra debug information.
This change moves back to a release build.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
