### PR TITLE
Pin krb5 to 1.17.*

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   missing_dso_whitelist:
     - /usr/lib/libncurses.5.4.dylib  # [osx]
@@ -40,7 +40,7 @@ requirements:
     - libedit
     - ncurses
     - xz
-    - krb5
+    - krb5 1.17.*
   run:
     - openssl
     - libaio  # [linux]
@@ -55,7 +55,7 @@ requirements:
     - libedit
     - ncurses
     - xz
-    - krb5
+    - krb5 1.17.*
 
 test:
   commands:


### PR DESCRIPTION
There are conflicts with krb5 1.19 and the r ecosystem. We avoid this
for now by temporarily pinning krb5 to 1.17

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
