### PR TITLE
Add build variants for openssl 1.1.1/3 and  curl 7/8

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,12 +8,12 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_openssl1.1.1:
-        CONFIG: linux_64_openssl1.1.1
+      linux_64_curl7openssl1.1.1:
+        CONFIG: linux_64_curl7openssl1.1.1
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_openssl3:
-        CONFIG: linux_64_openssl3
+      linux_64_curl8openssl3:
+        CONFIG: linux_64_curl8openssl3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,11 +8,11 @@ jobs:
     vmImage: macOS-11
   strategy:
     matrix:
-      osx_64_openssl1.1.1:
-        CONFIG: osx_64_openssl1.1.1
+      osx_64_curl7openssl1.1.1:
+        CONFIG: osx_64_curl7openssl1.1.1
         UPLOAD_PACKAGES: 'True'
-      osx_64_openssl3:
-        CONFIG: osx_64_openssl3
+      osx_64_curl8openssl3:
+        CONFIG: osx_64_curl8openssl3
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 

--- a/.ci_support/linux_64_curl7openssl1.1.1.yaml
+++ b/.ci_support/linux_64_curl7openssl1.1.1.yaml
@@ -1,9 +1,7 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.14'
-MACOSX_SDK_VERSION:
-- '10.14'
 bzip2:
 - '1'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,17 +9,15 @@ channel_targets:
 curl:
 - '7'
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '14'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 krb5:
 - '1.20'
-libiconv:
-- '1'
 lz4_c:
 - 1.9.3
-macos_machine:
-- x86_64-apple-darwin13.4.0
 ncurses:
 - '6'
 openssl:
@@ -29,9 +25,12 @@ openssl:
 pcre2:
 - '10.40'
 target_platform:
-- osx-64
+- linux-64
 xz:
 - '5'
+zip_keys:
+- - openssl
+  - curl
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/linux_64_curl8openssl3.yaml
+++ b/.ci_support/linux_64_curl8openssl3.yaml
@@ -1,27 +1,23 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.14'
-MACOSX_SDK_VERSION:
-- '10.14'
 bzip2:
 - '1'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '14'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 krb5:
 - '1.20'
-libiconv:
-- '1'
 lz4_c:
 - 1.9.3
-macos_machine:
-- x86_64-apple-darwin13.4.0
 ncurses:
 - '6'
 openssl:
@@ -29,9 +25,12 @@ openssl:
 pcre2:
 - '10.40'
 target_platform:
-- osx-64
+- linux-64
 xz:
 - '5'
+zip_keys:
+- - openssl
+  - curl
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/linux_aarch64_curl7openssl1.1.1.yaml
+++ b/.ci_support/linux_aarch64_curl7openssl1.1.1.yaml
@@ -1,7 +1,11 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 bzip2:
 - '1'
+cdt_arch:
+- aarch64
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,9 +15,9 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-aarch64
 krb5:
 - '1.20'
 lz4_c:
@@ -25,9 +29,12 @@ openssl:
 pcre2:
 - '10.40'
 target_platform:
-- linux-64
+- linux-aarch64
 xz:
 - '5'
+zip_keys:
+- - openssl
+  - curl
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/linux_aarch64_curl8openssl3.yaml
+++ b/.ci_support/linux_aarch64_curl8openssl3.yaml
@@ -1,19 +1,23 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 bzip2:
 - '1'
+cdt_arch:
+- aarch64
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-aarch64
 krb5:
 - '1.20'
 lz4_c:
@@ -25,9 +29,12 @@ openssl:
 pcre2:
 - '10.40'
 target_platform:
-- linux-64
+- linux-aarch64
 xz:
 - '5'
+zip_keys:
+- - openssl
+  - curl
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/osx_64_curl7openssl1.1.1.yaml
+++ b/.ci_support/osx_64_curl7openssl1.1.1.yaml
@@ -1,11 +1,9 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.14'
 bzip2:
 - '1'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,25 +11,30 @@ channel_targets:
 curl:
 - '7'
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '11'
-docker_image:
-- quay.io/condaforge/linux-anvil-aarch64
+- '15'
 krb5:
 - '1.20'
+libiconv:
+- '1'
 lz4_c:
 - 1.9.3
+macos_machine:
+- x86_64-apple-darwin13.4.0
 ncurses:
 - '6'
 openssl:
-- '3'
+- 1.1.1
 pcre2:
 - '10.40'
 target_platform:
-- linux-aarch64
+- osx-64
 xz:
 - '5'
+zip_keys:
+- - openssl
+  - curl
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/osx_64_curl8openssl3.yaml
+++ b/.ci_support/osx_64_curl8openssl3.yaml
@@ -1,37 +1,40 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.14'
 bzip2:
 - '1'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 curl:
-- '7'
+- '8'
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '11'
-docker_image:
-- quay.io/condaforge/linux-anvil-aarch64
+- '15'
 krb5:
 - '1.20'
+libiconv:
+- '1'
 lz4_c:
 - 1.9.3
+macos_machine:
+- x86_64-apple-darwin13.4.0
 ncurses:
 - '6'
 openssl:
-- 1.1.1
+- '3'
 pcre2:
 - '10.40'
 target_platform:
-- linux-aarch64
+- osx-64
 xz:
 - '5'
+zip_keys:
+- - openssl
+  - curl
 zlib:
 - '1.2'
 zstd:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ language: generic
 
 matrix:
   include:
-    - env: CONFIG=linux_aarch64_openssl1.1.1 UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
+    - env: CONFIG=linux_aarch64_curl7openssl1.1.1 UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
       os: linux
       arch: arm64
       dist: focal
 
-    - env: CONFIG=linux_aarch64_openssl3 UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
+    - env: CONFIG=linux_aarch64_curl8openssl3 UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
       os: linux
       arch: arm64
       dist: focal

--- a/README.md
+++ b/README.md
@@ -47,45 +47,45 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_openssl1.1.1</td>
+              <td>linux_64_curl7openssl1.1.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8376&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_openssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_curl7openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_openssl3</td>
+              <td>linux_64_curl8openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8376&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_openssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_curl8openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_openssl1.1.1</td>
+              <td>linux_aarch64_curl7openssl1.1.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8376&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_openssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_curl7openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_openssl3</td>
+              <td>linux_aarch64_curl8openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8376&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_openssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_curl8openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_openssl1.1.1</td>
+              <td>osx_64_curl7openssl1.1.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8376&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_openssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_curl7openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_openssl3</td>
+              <td>osx_64_curl8openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8376&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_openssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_curl8openssl3" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,5 +3,13 @@ MACOSX_SDK_VERSION:  # [osx and x86_64]
 MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
   - "10.14"                # [osx and x86_64]
 openssl:
-- '1.1.1'
-- '3'
+  - '1.1.1'
+  - '1.1.1'
+  - '3'
+curl:
+  - 7
+  - 7
+  - 8
+zip_keys:
+  - 'openssl'
+  - 'curl'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   missing_dso_whitelist:
     - /usr/lib/libncurses.5.4.dylib  # [osx]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

This adds build variants for openssl 1.1.1 and 3 for curl 7 and 8. This aligns with TileDB package variants.

<!--
Please add any other relevant info below:
-->
