### PR TITLE
Bump build number for 0.26.0 build

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -7,3 +7,4 @@ github:
   tooling_branch_name: main
 conda_build:
   pkg_format: '2'
+upload_on_branch: main

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,10 +1,10 @@
 provider:
   linux_aarch64: default
 conda_forge_output_validation: true
-test_on_native_only: true
 github:
   branch_name: main
   tooling_branch_name: main
 conda_build:
   pkg_format: '2'
 upload_on_branch: main
+test: native_and_emulated

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   missing_dso_whitelist:
     - /usr/lib/libncurses.5.4.dylib  # [osx]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [👋] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

We somehow ended up with duplicate artifacts at the same build number, and one of them (`libtiledb-sql-0.26.0-h6641145_0`) appears to have the wrong pins.

![image](https://github.com/conda-forge/libtiledb-sql-feedstock/assets/327706/dd9a300d-0b4f-4958-905e-a3f5adf0fa30)

