### PR TITLE
Rerender with libcurl and krb5 pins

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,12 +8,16 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_curl7openssl1.1.1:
-        CONFIG: linux_64_curl7openssl1.1.1
+      linux_64_krb51.20libcurl7openssl1.1.1:
+        CONFIG: linux_64_krb51.20libcurl7openssl1.1.1
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_curl8openssl3:
-        CONFIG: linux_64_curl8openssl3
+      linux_64_krb51.20libcurl7openssl3:
+        CONFIG: linux_64_krb51.20libcurl7openssl3
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_krb51.21libcurl8openssl3:
+        CONFIG: linux_64_krb51.21libcurl8openssl3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,11 +8,14 @@ jobs:
     vmImage: macOS-11
   strategy:
     matrix:
-      osx_64_curl7openssl1.1.1:
-        CONFIG: osx_64_curl7openssl1.1.1
+      osx_64_krb51.20libcurl7openssl1.1.1:
+        CONFIG: osx_64_krb51.20libcurl7openssl1.1.1
         UPLOAD_PACKAGES: 'True'
-      osx_64_curl8openssl3:
-        CONFIG: osx_64_curl8openssl3
+      osx_64_krb51.20libcurl7openssl3:
+        CONFIG: osx_64_krb51.20libcurl7openssl3
+        UPLOAD_PACKAGES: 'True'
+      osx_64_krb51.21libcurl8openssl3:
+        CONFIG: osx_64_krb51.21libcurl8openssl3
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 

--- a/.ci_support/linux_64_krb51.20libcurl7openssl1.1.1.yaml
+++ b/.ci_support/linux_64_krb51.20libcurl7openssl1.1.1.yaml
@@ -1,25 +1,21 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 bzip2:
 - '1'
-cdt_arch:
-- aarch64
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '7'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '12'
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 krb5:
 - '1.20'
+libcurl:
+- '7'
 lz4_c:
 - 1.9.3
 ncurses:
@@ -29,12 +25,13 @@ openssl:
 pcre2:
 - '10.42'
 target_platform:
-- linux-aarch64
+- linux-64
 xz:
 - '5'
 zip_keys:
 - - openssl
-  - curl
+  - libcurl
+  - krb5
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/linux_64_krb51.20libcurl7openssl3.yaml
+++ b/.ci_support/linux_64_krb51.20libcurl7openssl3.yaml
@@ -1,0 +1,38 @@
+bzip2:
+- '1'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+krb5:
+- '1.20'
+libcurl:
+- '7'
+lz4_c:
+- 1.9.3
+ncurses:
+- '6'
+openssl:
+- '3'
+pcre2:
+- '10.42'
+target_platform:
+- linux-64
+xz:
+- '5'
+zip_keys:
+- - openssl
+  - libcurl
+  - krb5
+zlib:
+- '1.2'
+zstd:
+- '1.5'

--- a/.ci_support/linux_64_krb51.21libcurl8openssl3.yaml
+++ b/.ci_support/linux_64_krb51.21libcurl8openssl3.yaml
@@ -1,27 +1,23 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.14'
-MACOSX_SDK_VERSION:
-- '10.14'
 bzip2:
 - '1'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '8'
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '16'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 krb5:
-- '1.20'
-libiconv:
-- '1'
+- '1.21'
+libcurl:
+- '8'
 lz4_c:
 - 1.9.3
-macos_machine:
-- x86_64-apple-darwin13.4.0
 ncurses:
 - '6'
 openssl:
@@ -29,12 +25,13 @@ openssl:
 pcre2:
 - '10.42'
 target_platform:
-- osx-64
+- linux-64
 xz:
 - '5'
 zip_keys:
 - - openssl
-  - curl
+  - libcurl
+  - krb5
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/linux_aarch64_krb51.20libcurl7openssl1.1.1.yaml
+++ b/.ci_support/linux_aarch64_krb51.20libcurl7openssl1.1.1.yaml
@@ -10,8 +10,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -20,12 +18,14 @@ docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 krb5:
 - '1.20'
+libcurl:
+- '7'
 lz4_c:
 - 1.9.3
 ncurses:
 - '6'
 openssl:
-- '3'
+- 1.1.1
 pcre2:
 - '10.42'
 target_platform:
@@ -34,7 +34,8 @@ xz:
 - '5'
 zip_keys:
 - - openssl
-  - curl
+  - libcurl
+  - krb5
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/linux_aarch64_krb51.20libcurl7openssl3.yaml
+++ b/.ci_support/linux_aarch64_krb51.20libcurl7openssl3.yaml
@@ -1,0 +1,42 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+bzip2:
+- '1'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+krb5:
+- '1.20'
+libcurl:
+- '7'
+lz4_c:
+- 1.9.3
+ncurses:
+- '6'
+openssl:
+- '3'
+pcre2:
+- '10.42'
+target_platform:
+- linux-aarch64
+xz:
+- '5'
+zip_keys:
+- - openssl
+  - libcurl
+  - krb5
+zlib:
+- '1.2'
+zstd:
+- '1.5'

--- a/.ci_support/linux_aarch64_krb51.21libcurl8openssl3.yaml
+++ b/.ci_support/linux_aarch64_krb51.21libcurl8openssl3.yaml
@@ -1,21 +1,25 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 bzip2:
 - '1'
+cdt_arch:
+- aarch64
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '12'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-aarch64
 krb5:
-- '1.20'
+- '1.21'
+libcurl:
+- '8'
 lz4_c:
 - 1.9.3
 ncurses:
@@ -25,12 +29,13 @@ openssl:
 pcre2:
 - '10.42'
 target_platform:
-- linux-64
+- linux-aarch64
 xz:
 - '5'
 zip_keys:
 - - openssl
-  - curl
+  - libcurl
+  - krb5
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/osx_64_krb51.20libcurl7openssl1.1.1.yaml
+++ b/.ci_support/osx_64_krb51.20libcurl7openssl1.1.1.yaml
@@ -1,23 +1,27 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.14'
 bzip2:
 - '1'
-cdt_name:
-- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '7'
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '16'
 krb5:
 - '1.20'
+libcurl:
+- '7'
+libiconv:
+- '1'
 lz4_c:
 - 1.9.3
+macos_machine:
+- x86_64-apple-darwin13.4.0
 ncurses:
 - '6'
 openssl:
@@ -25,12 +29,13 @@ openssl:
 pcre2:
 - '10.42'
 target_platform:
-- linux-64
+- osx-64
 xz:
 - '5'
 zip_keys:
 - - openssl
-  - curl
+  - libcurl
+  - krb5
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/osx_64_krb51.20libcurl7openssl3.yaml
+++ b/.ci_support/osx_64_krb51.20libcurl7openssl3.yaml
@@ -1,0 +1,42 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.14'
+bzip2:
+- '1'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+krb5:
+- '1.20'
+libcurl:
+- '7'
+libiconv:
+- '1'
+lz4_c:
+- 1.9.3
+macos_machine:
+- x86_64-apple-darwin13.4.0
+ncurses:
+- '6'
+openssl:
+- '3'
+pcre2:
+- '10.42'
+target_platform:
+- osx-64
+xz:
+- '5'
+zip_keys:
+- - openssl
+  - libcurl
+  - krb5
+zlib:
+- '1.2'
+zstd:
+- '1.5'

--- a/.ci_support/osx_64_krb51.21libcurl8openssl3.yaml
+++ b/.ci_support/osx_64_krb51.21libcurl8openssl3.yaml
@@ -8,14 +8,14 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-curl:
-- '7'
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '16'
 krb5:
-- '1.20'
+- '1.21'
+libcurl:
+- '8'
 libiconv:
 - '1'
 lz4_c:
@@ -25,7 +25,7 @@ macos_machine:
 ncurses:
 - '6'
 openssl:
-- 1.1.1
+- '3'
 pcre2:
 - '10.42'
 target_platform:
@@ -34,7 +34,8 @@ xz:
 - '5'
 zip_keys:
 - - openssl
-  - curl
+  - libcurl
+  - krb5
 zlib:
 - '1.2'
 zstd:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+
+language: generic
+
+
+
+matrix:
+  include:
+    - env: CONFIG=linux_aarch64_krb51.20libcurl7openssl1.1.1 UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
+      os: linux
+      arch: arm64
+      dist: focal
+
+    - env: CONFIG=linux_aarch64_krb51.20libcurl7openssl3 UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
+      os: linux
+      arch: arm64
+      dist: focal
+
+    - env: CONFIG=linux_aarch64_krb51.21libcurl8openssl3 UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
+      os: linux
+      arch: arm64
+      dist: focal
+
+script:
+  - export CI=travis
+  - export GIT_BRANCH="$TRAVIS_BRANCH"
+  - export flow_run_id="travis_$TRAVIS_JOB_ID"
+  - export sha="$TRAVIS_COMMIT"
+  - export remote_url="https://github.com/$TRAVIS_REPO_SLUG"
+  - export FEEDSTOCK_NAME=$(basename ${TRAVIS_REPO_SLUG})
+  - if [[ "${TRAVIS_PULL_REQUEST:-}" == "false" ]]; then export IS_PR_BUILD="False"; else export IS_PR_BUILD="True"; fi
+
+
+  - if [[ ${PLATFORM} =~ .*linux.* ]]; then CONDA_FORGE_DOCKER_RUN_ARGS="--network=host --security-opt=seccomp=unconfined" ./.scripts/run_docker_build.sh; fi

--- a/README.md
+++ b/README.md
@@ -47,45 +47,66 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_curl7openssl1.1.1</td>
+              <td>linux_64_krb51.20libcurl7openssl1.1.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8376&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_curl7openssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_krb51.20libcurl7openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_curl8openssl3</td>
+              <td>linux_64_krb51.20libcurl7openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8376&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_curl8openssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_krb51.20libcurl7openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_curl7openssl1.1.1</td>
+              <td>linux_64_krb51.21libcurl8openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8376&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_curl7openssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_krb51.21libcurl8openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_curl8openssl3</td>
+              <td>linux_aarch64_krb51.20libcurl7openssl1.1.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8376&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_curl8openssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_krb51.20libcurl7openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_curl7openssl1.1.1</td>
+              <td>linux_aarch64_krb51.20libcurl7openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8376&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_curl7openssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_krb51.20libcurl7openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_curl8openssl3</td>
+              <td>linux_aarch64_krb51.21libcurl8openssl3</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8376&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_curl8openssl3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_krb51.21libcurl8openssl3" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_krb51.20libcurl7openssl1.1.1</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8376&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_krb51.20libcurl7openssl1.1.1" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_krb51.20libcurl7openssl3</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8376&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_krb51.20libcurl7openssl3" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_krb51.21libcurl8openssl3</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8376&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libtiledb-sql-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_krb51.21libcurl8openssl3" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -10,6 +10,11 @@ libcurl:
   - 7
   - 7
   - 8
+krb5:
+  - 1.20
+  - 1.20
+  - 1.21
 zip_keys:
   - 'openssl'
   - 'libcurl'
+  - 'krb5'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   missing_dso_whitelist:
     - /usr/lib/libncurses.5.4.dylib  # [osx]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

---

Follow up to PR #142 (which superseded #139). It properly replaced curl with libcurl, but didn't rerender. Rerendering is challenging because conda-forge is migrating from krb5 1.20 to 1.21 (see automated PRs #127, #138, and #143, which all failed), but this feedstock is still building against the outdated libcurl 7. In order to build against libcurl 7 (which requires krb5 1.20) and libcurl 8 (which requires krb5 1.21), I added krb5 to `conda_build_config.yaml`.

Even more details:
* This hadn't been a problem with libtiledb since it was accidentally being pinned against curl instead of libcurl. This was fixed in https://github.com/conda-forge/tiledb-feedstock/pull/225 (which created tiledb 2.18.2 build 2)
* libcurl was built against krb5 1.20 up till 8.3. However, libcurl uses the standard run exports min pin of `"x.x.x.x"`, so tiledb 2.19.0 and 2.19.1 were built against libcurl 8.5, which prevented installing libcurl 8.3 plus krb5 1.20

Also note: once we stopping supporting openssl1 and libcurl 7, all this extra stuff from `conda_build_config.yaml` can be removed