### PR TITLE
Migrate to krb5 1.21

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+krb5:
+- '1.21'
 libcurl:
 - '8'
 lz4_c:

--- a/.ci_support/migrations/krb5121.yaml
+++ b/.ci_support/migrations/krb5121.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+krb5:
+- '1.21'
+migrator_ts: 1689171408.1479406

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '16'
+krb5:
+- '1.21'
 libcurl:
 - '8'
 libiconv:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '16'
+krb5:
+- '1.21'
 libcurl:
 - '8'
 libiconv:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - libedit
     - ncurses
     - xz
-    - krb5 1.21.*
+    - krb5
     - pcre2
   run:
     - openssl
@@ -55,7 +55,7 @@ requirements:
     - libedit
     - ncurses
     - xz
-    - krb5 1.21.* # unclear why we have this, but pin to fix solver conflict
+    - krb5
     - pcre2
 
 test:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

This PR fixes the recent krb5-related problems identified in #155. Note that I purposefully didn't bump the build number because the purpose of this PR is return management of krb5 back to the default conda-forge mechanism. Pinning krb5 1.21 in the recipe versus the config file has the same effect on the solver in the end.

Here is how we got here:

* The current conda-forge pin for [krb5 is 1.20](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/af0ac194753e20dea79121c6e529a03ef4e69928/recipe/conda_build_config.yaml#L444-L445). However, there is an ongoing [migration to krb5 1.21](https://conda-forge.org/status/migration/krb5121)
* Thus the bot made multiple attempts to migrate the repo to krb5 1.21 (#127, #138, #143). These all failed because the solver couldn't co-install all the required dependencies with the combination of krb5 1.21 and libcurl 7
* I previously solved the problem in #144 by manually specifying the build variants to install krb5 1.20 with libcurl 7 and krb5 1.21 with libcurl 8
* Now that we no longer need to support libcurl 7, @ihnorton dropped the custom pins in `conda_build_config.yaml` (#155). But then rerendering pins krb5 1.20, which generates a solver error
* Since I had previously closed the bot krb5 1.21 migration PRs, conda-forge assumed the migration was successful, so no more bot PRs will arrive
* One option would be to continue to manually pin `krb5` to 1.21 in `conda_build_config.yaml`. Instead I chose to copy the bot PRs and apply the migration patch