### PR TITLE
Rely on run exports for runtime pinning of shared libraries

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,21 +42,6 @@ requirements:
     - xz
     - krb5
     - pcre2
-  run:
-    - openssl
-    - libaio  # [linux]
-    - libiconv  # [osx]
-    - tiledb 2.22.*
-    - libcurl
-    - zlib
-    - bzip2
-    - zstd
-    - lz4-c
-    - libedit
-    - ncurses
-    - xz
-    - krb5
-    - pcre2
 
 test:
   commands:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

This PR updates the recipe to rely on the conda mechanism [run exports](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#export-runtime-requirements) to pin the runtime versions of shared libraries.

Below is the before and after of running `conda render recipe/` on a linux-64 machine:

```sh
# before
conda render recipe/
##   run:
##     - pcre2 >=10.43,<10.44.0a0
##     - zstd >=1.5.5,<1.6.0a0
##     - libaio >=0.3.113,<0.4.0a0
##     - libcurl >=8.7.1,<9.0a0
##     - xz >=5.2.6,<6.0a0
##     - openssl >=3.2.1,<4.0a0
##     - libzlib >=1.2.13,<1.3.0a0
##     - zlib
##     - ncurses >=6.4.20240210,<7.0a0
##     - lz4-c >=1.9.4,<1.10.0a0
##     - krb5 >=1.21.2,<1.22.0a0
##     - tiledb 2.22.*
##     - tiledb >=2.22.0,<2.23.0a0
##     - libgcc-ng >=13
##     - libstdcxx-ng >=13
##     - libedit >=3.1.20191231,<3.2.0a0
##     - bzip2 >=1.0.8,<2.0a0

# after
conda render recipe/
##   run:
##     - tiledb >=2.22.0,<2.23.0a0
##     - zstd >=1.5.5,<1.6.0a0
##     - libzlib >=1.2.13,<1.3.0a0
##     - libcurl >=8.7.1,<9.0a0
##     - libstdcxx-ng >=13
##     - openssl >=3.2.1,<4.0a0
##     - ncurses >=6.4.20240210,<7.0a0
##     - lz4-c >=1.9.4,<1.10.0a0
##     - krb5 >=1.21.2,<1.22.0a0
##     - libaio >=0.3.113,<0.4.0a0
##     - pcre2 >=10.43,<10.44.0a0
##     - libgcc-ng >=13
##     - xz >=5.2.6,<6.0a0
##     - bzip2 >=1.0.8,<2.0a0
##     - libedit >=3.1.20191231,<3.2.0a0
```

The only differences are:

* No duplicate `tiledb` pin
* `libzlib` instead of `zlib` (as [expected](https://github.com/conda-forge/zlib-feedstock/blob/7e99a51a0a26a5062400ba307c96435a77dded4e/recipe/meta.yaml#L32))

I also confirmed that the [libiconv-feedstock recipe uses run exports](https://github.com/conda-forge/libiconv-feedstock/blob/1d9169eefd3adb9b4171475c10d6fa909b48dcae/recipe/meta.yaml#L41), since that is a osx only requirement.

I'm also hoping that removing `zlib` from the run requirements will remove this conda-build WARNING:

```sh
WARNING (libtiledb-sql): run-exports library package conda-forge/linux-64::zlib==1.2.13=hd590300_5 in requirements/run but it is not used (i.e. it is overdepending or perhaps statically linked? If that is what you want then add it to `build/ignore_run_exports`)
```

