### PR TITLE
Migrate to stdlib("c")

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jdblischak @DimitrisStaratzis @ihnorton @shelnutt2
+* @DimitrisStaratzis @ihnorton @jdblischak @shelnutt2

--- a/README.md
+++ b/README.md
@@ -191,5 +191,6 @@ Feedstock Maintainers
 
 * [@DimitrisStaratzis](https://github.com/DimitrisStaratzis/)
 * [@ihnorton](https://github.com/ihnorton/)
+* [@jdblischak](https://github.com/jdblischak/)
 * [@shelnutt2](https://github.com/shelnutt2/)
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,4 @@
 MACOSX_SDK_VERSION:  # [osx and x86_64]
   - 10.14            # [osx and x86_64]
-MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
-  - "10.14"                # [osx and x86_64]
+c_stdlib_version:    # [osx and x86_64]
+  - 10.14            # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   missing_dso_whitelist:
     - /usr/lib/libncurses.5.4.dylib  # [osx]
@@ -27,6 +27,7 @@ requirements:
     - libaio  # [linux]
     - libiconv  # [osx]
     - {{ compiler('cxx') }}
+    - {{ stdlib("c") }}
     - bison
   host:
     - openssl


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

conda-forge has started a new migration to properly pin the version of the C standard library used in all its recipes. You can find more details in their blog post [Upcoming migration for stdlib("c")](https://conda-forge.org/news/2024/03/24/stdlib-migration/)

When rerendering, we started receiving the following WARNING from conda-smithy:

```
* WARNING:conda_smithy.configure_feedstock:Conflicting specification for minimum macOS deployment target!
If your conda_build_config.yaml sets `MACOSX_DEPLOYMENT_TARGET`, please change the name of that key to `c_stdlib_version`!
Using 10.14=max(c_stdlib_version, MACOSX_DEPLOYMENT_TARGET).
```

To remove the warning, I renamed the key in `conda_build_config.yaml` to `c_stdlib_version` and also added `{{ stdlib("c") }}` to the build requirements.

Note that I did bump the build number so that we can get a new binary that incorporates the changes from this PR as well as from my recent PRs (#157, #160, #161).
